### PR TITLE
🐛 Fix: 클래스 카드 컴포넌트 수정, 태그선택 페이지 간격 수정

### DIFF
--- a/src/components/common/ClassCard.tsx
+++ b/src/components/common/ClassCard.tsx
@@ -24,7 +24,7 @@ export default function ClassCard({
   imageUrl
 }: ClassCardProps) {
   return (
-          <div className="rounded-[16px] bg-white pt-[12px] pr-[12px] pb-[12px] relative">
+    <div className="rounded-[16px] relative">
       <div className="flex gap-[5px]">
         <div className="w-[130px] h-[130px] bg-[#B3B3B3] rounded-[20px]">
           {imageUrl && <img src={imageUrl} alt={title} className="w-full h-full object-cover rounded-[20px]" />}

--- a/src/pages/Recommend/RecommendPage.tsx
+++ b/src/pages/Recommend/RecommendPage.tsx
@@ -89,7 +89,7 @@ const RecommendPage: React.FC = () => {
         {hasSelectedTags ? (
           <>
             {/* 클래스 목록 */}
-            <div>
+            <div className="space-y-[18px] mt-[30px]">
               {mockClasses.map((classData) => (
                 <ClassCardWrapper key={classData.id} classData={classData} />
               ))}

--- a/src/pages/Tag/TagSelectPage.tsx
+++ b/src/pages/Tag/TagSelectPage.tsx
@@ -145,17 +145,15 @@ export default function TagSelectPage() {
             <div className={`w-full max-w-[430px] h-[650px] rounded-t-[20px] bg-[#FDFDFD] shadow-[0_-4px_16px_rgba(0,0,0,0.1)] transform transition-all duration-500 ease-out ${isSheetOpen ? 'translate-y-0 opacity-100' : 'translate-y-full opacity-0'}`}>
               <div className="pt-[12px] px-[16px]">
                 <div className="mx-auto h-[4px] w-[120px] rounded-full bg-[#C7C7C7]" />
-                <div className="mt-[12px] flex items-start justify-center relative">
-                  <div className="inline-flex items-center rounded-[20px] bg-[#009DFF] px-[14px] py-[8px] shadow-[0_4px_4px_2px_rgba(0,0,0,0.04)] mt-[7px] ml-[22px]">
+                <div className="items-start justify-center">
+                  <div className="px-[56px] mt-[35px]">
+                  <div className="inline-flex items-center rounded-[20px] bg-[#009DFF] px-[14px] py-[8px] shadow-[0_4px_4px_2px_rgba(0,0,0,0.04)]">
                     <span className="text-white text-[14px] font-semibold tracking-[-0.01em]">"선택하신 태그에 딱 맞는 클래스를 모아봤어요!"</span>
                   </div>
-                  <button type="button" onClick={handleCloseSheet} className="absolute -right-[20px] -mt-[20px] w-[36px] h-[36px] relative" aria-label="닫기">
-                    <span className="absolute left-1/2 top-1/2 block h-[24px] w-[2px] -translate-x-1/2 -translate-y-1/2 rotate-45 bg-[#545454]" />
-                    <span className="absolute left-1/2 top-1/2 block h-[24px] w-[2px] -translate-x-1/2 -translate-y-1/2 -rotate-45 bg-[#545454]" />
-                  </button>
+                  </div>
                 </div>
               </div>
-              <div className="mt-[8px] px-[16px] pb-[45px] max-h-[60vh] overflow-y-auto">
+              <div className="mt-[20px] px-[16px] pb-[45px] space-y-[18px] max-h-[60vh] overflow-y-auto">
                 <ClassCard
                   title="한성대 영문과 학생과 함께하는 영어교실교실교실"
                   location="성북구성북구성북구성북구성북구성북구"


### PR DESCRIPTION
## 🚀 관련 이슈
- close #18 

## 🔑 작업 내용
- 클래스 카드 컴포넌트 수정, 태그선택 페이지 간격 수정
- 컴포넌트에 고유적으로 있는 패딩을 삭제합니다.

## 📷 스크린샷
<img width="431" height="929" alt="image" src="https://github.com/user-attachments/assets/fd156529-7d7c-4169-9117-db8ee64aee19" />


## 🌐 공유 사항 to 리뷰어

## 🚨 이슈 사항
